### PR TITLE
pass jshint style check

### DIFF
--- a/gaia-component.js
+++ b/gaia-component.js
@@ -1,11 +1,12 @@
-;(function(define){define(function(require,exports,module){
-'use strict';
-
+/* jshint node:true */
+/* globals define */
+;(function(define){'use strict';define(function(require,exports,module){
 /**
  * Locals
  */
 
-var textContent = Object.getOwnPropertyDescriptor(Node.prototype, 'textContent');
+var textContent = Object.getOwnPropertyDescriptor(Node.prototype,
+    'textContent');
 var innerHTML = Object.getOwnPropertyDescriptor(Element.prototype, 'innerHTML');
 var removeAttribute = Element.prototype.removeAttribute;
 var setAttribute = Element.prototype.setAttribute;
@@ -159,7 +160,9 @@ var base = {
         if (this.lightStyle) { this.appendChild(this.lightStyle); }
       },
 
-      get: textContent.get
+      get: function() {
+        return textContent.get();
+      }
     },
 
     innerHTML: {
@@ -192,9 +195,8 @@ var defaultPrototype = createProto(HTMLElement.prototype, base.properties);
 function getBaseProto(proto) {
   if (!proto) { return defaultPrototype; }
   proto = proto.prototype || proto;
-  return !proto.GaiaComponent
-    ? createProto(proto, base.properties)
-    : proto;
+  return !proto.GaiaComponent ?
+    createProto(proto, base.properties) : proto;
 }
 
 /**
@@ -284,11 +286,11 @@ function processCss(template, name) {
  * @param  {String} css
  */
 function injectGlobalCss(css) {
-  if (!css) return;
+  if (!css) {return;}
   var style = document.createElement('style');
   style.innerHTML = css.trim();
-  headReady().then(() => {
-    document.head.appendChild(style)
+  headReady().then(function() {
+    document.head.appendChild(style);
   });
 }
 
@@ -299,7 +301,7 @@ function injectGlobalCss(css) {
  * @private
  */
 function headReady() {
-  return new Promise(resolve => {
+  return new Promise(function(resolve) {
     if (document.head) { return resolve(); }
     window.addEventListener('load', function fn() {
       window.removeEventListener('load', fn);


### PR DESCRIPTION
@wilsonpage would you mind take a review?

to test with jshint, I did
- npm install jshint
- copy `.jshintrc` from gaia
- run command

```
./node_modules/jshint/bin/jshint gaia-component.js
```

Also fix a side issue:
The arrow function does not needed here, choose not to use arrow function in core module may help the future adoption from other browser (ex chrome) since it does not have arrow function support yet.
