### PR TITLE
Bug 1209041 - `dir` attribute support

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -253,7 +253,7 @@ suite('gaia-component', function() {
 
     test('component can listen for rtl changes', function(done) {
       var El = component.register('rtl-test', {
-        rtl: true,
+        dirObserver: true,
 
         created: function() {
           document.addEventListener('dirchanged', function() {


### PR DESCRIPTION
In order to use `<gaia-header>` with applications that are not ready yet for RTL navigation, we need to be able to force the component direction to LTR like this:

``` html
<gaia-header action="back" dir="ltr">
  <h1> title </h1>
</gaia-header>
```

If the `rtl: true` property is provided, this patch automatically sets all shadowRoot children direction (`dir` attributes) when the component is created and when the document direction is changed:
- when the component is created declaratively, the direction to apply is computed from the host, so that forcing a `dir="ltr"` becomes possible;
- when the component is created dynamically, the direction is assumed to be the same as the document element — which is not always true, but that should be enough until bug 1100912 is fixed.

`<gaia-header>` must be modifed a bit to work with this version of `<gaia-component>`.

@wilsonpage wdyt?
