### PR TITLE
Do not set attribute on internal node before createdCallback is called

### DIFF
--- a/gaia-component.js
+++ b/gaia-component.js
@@ -156,8 +156,10 @@ var base = {
      * @param {String} value
      */
     setAttr: function(name, value) {
-      var internal = this.shadowRoot.firstElementChild;
-      setAttribute.call(internal, name, value);
+      if (this.shadowRoot) {
+        var internal = this.shadowRoot.firstElementChild;
+        setAttribute.call(internal, name, value);
+      }
       setAttribute.call(this, name, value);
     },
 


### PR DESCRIPTION
For example:
var a = document.createElement('gaia-switch');
a.disabled = true;  // error presents
