### PR TITLE
add license, resolves #15

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2015, Mozilla Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "fxos-component",
   "homepage": "https://github.com/fxos-components/fxos-component",
   "version": "1.0.0",
+  "license": "Apache-2.0",
   "main": "src/fxos-component.js",
   "directories": {
     "example": "examples",


### PR DESCRIPTION
Related to #15

To stay consistant with Gaia we can use the Apache 2.0 license. I asked about this when we started working on [Vaani](https://github.com/mozilla/vaani/), but it wouldn't hurt to get someone else to confirm. Once we decied I can run through all the repos and do the same.
